### PR TITLE
Do not fail if apticron is already installed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,4 +34,5 @@
     src: /usr/sbin/apticron
     dest: "/etc/cron.{{ apticron_frequency }}/apticron"
     state: link
+    force: yes
   when: apticron_email is defined


### PR DESCRIPTION
If a server has apticron previously installed, /etc/cron.daily/apticron
is already existent, so our apticron must be forcibly installed.

Fix issue #3.