### PR TITLE
Remove script also from cron.d

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,7 @@
     path="/etc/cron.{{ item }}/apticron"
     state=absent
   with_items:
+    - d
     - daily
     - hourly
     - monthly


### PR DESCRIPTION
By default, recent debian installs the apticron script into cron.d:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=587597

You will end up with a double email notification.

Removing that script before creating the symlink solves the problem.